### PR TITLE
Enable String Serializer to support strings with special characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ bin/
 typings/
 reports/
 *.log
+.idea/
+*.iml

--- a/src/main/SerializationHelper.ts
+++ b/src/main/SerializationHelper.ts
@@ -139,7 +139,7 @@ export class DateSerializer implements Serializer {
 @CacheKey("StringSerializer")
 class StringSerializer implements Serializer {
     serialize = (value: string): string => {
-        return '"' + value + '"';
+        return JSON.stringify(value);
     }
 }
 @CacheKey("NumberSerializer")

--- a/src/test/SerializationHelper.spec.ts
+++ b/src/test/SerializationHelper.spec.ts
@@ -11,6 +11,9 @@ describe("Testing SerializationHelper methods", () => {
     it("Testing SerializeStringType", () => {
         expect(serializeFunctions[Constants.STRING_TYPE]("test", "testString", serializers[Constants.STRING_TYPE])).toBe('"test":"testString"');
     });
+    it("Testing SerializeStringType with quotes", () => {
+        expect(serializeFunctions[Constants.STRING_TYPE]("test", `testString 'with' "quotes"`, serializers[Constants.STRING_TYPE])).toBe('"test":"testString \'with\' \\"quotes\\""');
+    });
     it("Testing SerializeBooleanType", () => {
         expect(serializeFunctions[Constants.BOOLEAN_TYPE]("test", true, serializers[Constants.BOOLEAN_TYPE])).toBe('"test":true');
     });


### PR DESCRIPTION
Hi,

I was getting strange JSON parsing issues when I discovered that the StringSerializer class was not catering for any characters that may need to be escaped.

I have added a test to cover the scenario that I encountered, which now passes.