### PR TITLE
Remove reflect-metadata from dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,15 @@ Originally, I thought of not having to force a dependency on another library.
 But when you look the geneated JS code for a `typescript` decorator, 
 it is always trying to check for the variable `Reflect`. So, until such time when
 `typescript` decorators can be de-coupled from `Reflect` library, I am sticking with it.
-
+You can either download `reflect-metadata` from there or from npmjs.com with the `npm` command:
+```
+npm install reflect-metadata --save
+```
+and make sure to import it in a global place, like app.ts:
+```typescript
+import "reflect-metadata";
+```
+If you are using Angular 2 you should already have this shim installed.
 ## Things to remember
 ### Enum serialization and de-serialization
 You can use `enum` data type by specifying the `type` property of @JsonProperty decorator.

--- a/dist/ObjectMapper.es2015.js
+++ b/dist/ObjectMapper.es2015.js
@@ -1,5 +1,3 @@
-import 'reflect-metadata';
-
 function __decorate(decorators, target, key, desc) {
     var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
     if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);

--- a/dist/ObjectMapper.es2015.js
+++ b/dist/ObjectMapper.es2015.js
@@ -429,7 +429,7 @@ var DateSerializer = (function () {
 var StringSerializer = (function () {
     function StringSerializer() {
         this.serialize = function (value) {
-            return '"' + value + '"';
+            return JSON.stringify(value);
         };
     }
     StringSerializer = __decorate([

--- a/package.json
+++ b/package.json
@@ -55,6 +55,5 @@
     "typings": "^0.8.1"
   },
   "dependencies": {
-    "reflect-metadata": "^0.1.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,12 +48,12 @@
     "karma-spec-reporter": "0.0.26",
     "karma-typescript": "^2.1.4",
     "process": "^0.11.9",
+    "reflect-metadata": "^0.1.10",
     "rollup": "^0.38.3",
     "rollup-plugin-typescript": "^0.8.1",
     "tslint": "^3.10.2",
     "typescript": "^2.0.10",
     "typings": "^0.8.1"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/src/main/ReflectHelper.ts
+++ b/src/main/ReflectHelper.ts
@@ -4,6 +4,8 @@
 
 import { JsonPropertyDecoratorMetadata, JSON_PROPERTY_DECORATOR_NAME } from './DecoratorMetadata';
 
+declare var Reflect: any;
+
 /**
  * Returns the JsonProperty decorator metadata.
  */

--- a/src/main/ReflectHelper.ts
+++ b/src/main/ReflectHelper.ts
@@ -2,7 +2,6 @@
  * Helper functions for JS reflections.
  */
 
-import 'reflect-metadata';
 import { JsonPropertyDecoratorMetadata, JSON_PROPERTY_DECORATOR_NAME } from './DecoratorMetadata';
 
 /**

--- a/src/test/ClassDecorator.spec.ts
+++ b/src/test/ClassDecorator.spec.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../typings/index.d.ts"/>
+import "reflect-metadata";
 import { JsonProperty, JsonPropertyDecoratorMetadata, AccessType, Serializer, Deserializer } from "../main/DecoratorMetadata";
 import { getOrCreateDeserializer, deserializers } from "../main/DeserializationHelper";
 import { getOrCreateSerializer, serializers } from "../main/SerializationHelper";

--- a/src/test/DecoratorMetadata.spec.ts
+++ b/src/test/DecoratorMetadata.spec.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../typings/index.d.ts"/>
+import "reflect-metadata";
 import { JsonProperty, JsonPropertyDecoratorMetadata, AccessType } from "../main/DecoratorMetadata";
 import { getJsonPropertyDecoratorMetadata } from "../main/ReflectHelper";
 

--- a/src/test/DeserializationHelper.spec.ts
+++ b/src/test/DeserializationHelper.spec.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../typings/index.d.ts"/>
+import "reflect-metadata";
 import { DeserializeSimpleType, DeserializeArrayType, DeserializeDateType, DeserializeComplexType } from "../main/DeserializationHelper";
 import { JsonProperty, JsonPropertyDecoratorMetadata, AccessType } from "../main/DecoratorMetadata";
 

--- a/src/test/DeserializeDataset.spec.ts
+++ b/src/test/DeserializeDataset.spec.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../typings/index.d.ts"/>
+import "reflect-metadata";
 import { JsonProperty, JsonPropertyDecoratorMetadata, AccessType, Deserializer } from "../main/DecoratorMetadata";
 import { ObjectMapper } from "../main/index";
 import { Map } from "es6-shim";

--- a/src/test/DeserializeLargeDataSet2.spec.ts
+++ b/src/test/DeserializeLargeDataSet2.spec.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../typings/index.d.ts"/>
+import "reflect-metadata";
 import { JsonProperty, JsonPropertyDecoratorMetadata, AccessType } from "../main/DecoratorMetadata";
 import { ObjectMapper } from "../main/index";
 import { isArrayType } from "../main/ReflectHelper";

--- a/src/test/DeserializeLargeDataset3.spec.ts
+++ b/src/test/DeserializeLargeDataset3.spec.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../typings/index.d.ts"/>
+import "reflect-metadata";
 import { JsonProperty } from "../main/DecoratorMetadata";
 import { ObjectMapper } from "../main/index";
 describe("Tesing large dataset from https://raw.githubusercontent.com/openfootball/football.json/master/2016-17/en.1.json", () => {

--- a/src/test/DeserializeLargeDataset3.spec.ts
+++ b/src/test/DeserializeLargeDataset3.spec.ts
@@ -1,4 +1,3 @@
-import "reflect-metadata";
 import { JsonProperty } from "../main/DecoratorMetadata";
 import { ObjectMapper } from "../main/index";
 describe("Tesing large dataset from https://raw.githubusercontent.com/openfootball/football.json/master/2016-17/en.1.json", () => {
@@ -7,17 +6,10 @@ describe("Tesing large dataset from https://raw.githubusercontent.com/openfootba
     });
 });
 
-
-class League{
+class Team{
+    key: String = undefined;
     name: String = undefined;
-    @JsonProperty({type: Round})
-    rounds: Round[] = undefined;
-}
-
-class Round{
-    name: string = undefined;
-    @JsonProperty({type:Match})
-    matches: Match[] = undefined;    
+    code: String = undefined;
 }
 
 class Match{
@@ -28,11 +20,19 @@ class Match{
     @JsonProperty({type:Team})
     team2: Team = undefined;
 }
-class Team{
-    key: String = undefined;
-    name: String = undefined;
-    code: String = undefined;
+
+class Round{
+    name: string = undefined;
+    @JsonProperty({type:Match})
+    matches: Match[] = undefined;    
 }
+
+class League{
+    name: String = undefined;
+    @JsonProperty({type: Round})
+    rounds: Round[] = undefined;
+}
+
 /** Gathered from OpenFootball https://raw.githubusercontent.com/openfootball/football.json/master/2016-17/en.1.json */
 var json = {
     "name": "English Premier League 2016/17",

--- a/src/test/DeserializeLargeSets.spec.ts
+++ b/src/test/DeserializeLargeSets.spec.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../typings/index.d.ts"/>
+import "reflect-metadata";
 import { JsonProperty, JsonPropertyDecoratorMetadata, AccessType } from "../main/DecoratorMetadata";
 import { ObjectMapper } from "../main/index";
 import { isArrayType } from "../main/ReflectHelper";

--- a/src/test/NameSpaces.ts
+++ b/src/test/NameSpaces.ts
@@ -1,3 +1,4 @@
+import "reflect-metadata";
 import { JsonProperty} from "../main/DecoratorMetadata";
 export namespace a{
 

--- a/src/test/SerializationHelper.spec.ts
+++ b/src/test/SerializationHelper.spec.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../typings/index.d.ts"/>
+import "reflect-metadata";
 import { JsonProperty } from "../main/DecoratorMetadata";
 import { SerializeArrayType, SerializeObjectType, serializeFunctions, serializers, SerializationStructure } from "../main/SerializationHelper";
 import { getTypeNameFromInstance, Constants } from "../main/ReflectHelper";

--- a/src/test/SerializeLargeDataset1.spec.ts
+++ b/src/test/SerializeLargeDataset1.spec.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../typings/index.d.ts"/>
+import "reflect-metadata";
 import { JsonProperty } from "../main/DecoratorMetadata";
 import { ObjectMapper } from "../main/index";
 

--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../typings/index.d.ts"/>
+import "reflect-metadata";
 import { JsonProperty, JsonPropertyDecoratorMetadata, AccessType, Serializer, Deserializer } from "../main/DecoratorMetadata";
 import { ObjectMapper } from "../main/index";
 import { a, b } from "./NameSpaces";


### PR DESCRIPTION
It looks like es7 reflect metadata is now in [core-js](https://github.com/zloirock/core-js) .
This conflicts for Angular 2 applications.

For example see issue #4.