### PR TITLE
Bugfix JsonConverstionError types

### DIFF
--- a/dist/ObjectMapper.d.ts
+++ b/dist/ObjectMapper.d.ts
@@ -41,7 +41,7 @@ export function CacheKey(key: string): Function;
 /**
  * Json convertion error type.
  */
-export declare function JsonConverstionError(message, json);
+export declare function JsonConverstionError(message: string, json: any): Error;
 
 export declare namespace ObjectMapper {
 

--- a/src/main/DecoratorMetadata.ts
+++ b/src/main/DecoratorMetadata.ts
@@ -37,7 +37,7 @@ export interface Deserializer{
 /**
  * JsonProperty Decorator function.
  */
-export function JsonProperty(metadata?: JsonPropertyDecoratorMetadata): any {
+export function JsonProperty(metadata?: JsonPropertyDecoratorMetadata | string): any {
     if (typeof metadata === 'string') {
         return getJsonPropertyDecorator({ name: metadata as string, required: false, access: AccessType.BOTH });
     } else {


### PR DESCRIPTION
If TypeScript compiler option "noImplicitAny" enabled ObjectMapper.d.ts has error:

```
ERROR in [at-loader] ../../../json-object-mapper/dist/ObjectMapper.d.ts:44:25 
    TS7010: 'JsonConverstionError', which lacks return-type annotation, implicitly has an 'any' return type.

ERROR in [at-loader] ../../../json-object-mapper/dist/ObjectMapper.d.ts:44:46 
    TS7006: Parameter 'message' implicitly has an 'any' type.

ERROR in [at-loader] ../../../json-object-mapper/dist/ObjectMapper.d.ts:44:55 
    TS7006: Parameter 'json' implicitly has an 'any' type.
```

Update:
And fix error:
```
error TS2559: Type '"***"' has no properties in common with type 'JsonPropertyDecoratorMetadata'.
```