### PR TITLE
Bugfix test DeserializeLargeDataset3

### DIFF
--- a/src/test/DeserializeLargeDataset3.spec.ts
+++ b/src/test/DeserializeLargeDataset3.spec.ts
@@ -6,17 +6,10 @@ describe("Tesing large dataset from https://raw.githubusercontent.com/openfootba
     });
 });
 
-
-class League{
+class Team{
+    key: String = undefined;
     name: String = undefined;
-    @JsonProperty({type: Round})
-    rounds: Round[] = undefined;
-}
-
-class Round{
-    name: string = undefined;
-    @JsonProperty({type:Match})
-    matches: Match[] = undefined;    
+    code: String = undefined;
 }
 
 class Match{
@@ -27,11 +20,19 @@ class Match{
     @JsonProperty({type:Team})
     team2: Team = undefined;
 }
-class Team{
-    key: String = undefined;
-    name: String = undefined;
-    code: String = undefined;
+
+class Round{
+    name: string = undefined;
+    @JsonProperty({type:Match})
+    matches: Match[] = undefined;    
 }
+
+class League{
+    name: String = undefined;
+    @JsonProperty({type: Round})
+    rounds: Round[] = undefined;
+}
+
 /** Gathered from OpenFootball https://raw.githubusercontent.com/openfootball/football.json/master/2016-17/en.1.json */
 var json = {
     "name": "English Premier League 2016/17",


### PR DESCRIPTION
TypeScript v2.4.2 error:

```
src/test/DeserializeLargeDataset3.spec.ts(12,26): error TS2449: Class 'Round' used before its declaration.
src/test/DeserializeLargeDataset3.spec.ts(18,25): error TS2449: Class 'Match' used before its declaration.
src/test/DeserializeLargeDataset3.spec.ts(25,25): error TS2449: Class 'Team' used before its declaration.
src/test/DeserializeLargeDataset3.spec.ts(27,25): error TS2449: Class 'Team' used before its declaration.
```