### PR TITLE
No need to specify class properties as undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,11 @@ Lets have a look at an example:
 
 ```typescript
 class SimpleRoster {
+    @JsonProperty()
     private name: String;
+    @JsonProperty()
     private worksOnWeekend: Boolean;
+    @JsonProperty()
     private numberOfHours: Number;
     @JsonProperty({type:Date})
     private systemDate: Date;

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Lets have a look at an example:
 
 ```typescript
 class SimpleRoster {
-    private name: String = undefined;
-    private worksOnWeekend: Boolean = undefined;
-    private numberOfHours: Number = undefined;
+    private name: String;
+    private worksOnWeekend: Boolean;
+    private numberOfHours: Number;
     @JsonProperty({type:Date})
-    private systemDate: Date = undefined;
+    private systemDate: Date;
 
     public isAvailableToday(): Boolean {
         if (this.systemDate.getDay() % 6 == 0 && this.worksOnWeekend == false) {
@@ -147,7 +147,7 @@ enum Days{
 
 class Workday{
     @JsonProperty({ type: Days, deserializer: DaysEnumSerializerDeserializer, serializer: DaysEnumSerializerDeserializer})
-    today: Days = undefined;
+    today: Days;
 }        
 
 let json = { "today": 'Tues' };

--- a/dist/ObjectMapper.es2015.js
+++ b/dist/ObjectMapper.es2015.js
@@ -231,6 +231,10 @@ var DeserializeComplexType = function (instance, instanceKey, type, json, jsonKe
     }
     var objectKeys = Object.keys(objectInstance);
     objectKeys = objectKeys.concat((Reflect.getMetadata(METADATA_JSON_PROPERTIES_NAME, objectInstance) || []).filter(function (item) {
+        if (objectInstance.constructor.prototype.hasOwnProperty(item) && Object.getOwnPropertyDescriptor(objectInstance.constructor.prototype, item).set === undefined) {
+            // Property does not have setter
+            return false;
+        }
         return objectKeys.indexOf(item) < 0;
     }));
     objectKeys.forEach(function (key) {
@@ -375,6 +379,10 @@ var SerializeObjectType = function (parentStructure, instanceStructure, instance
     instanceStructure.visited = true;
     var objectKeys = Object.keys(instanceStructure.instance);
     objectKeys = objectKeys.concat((Reflect.getMetadata(METADATA_JSON_PROPERTIES_NAME, instanceStructure.instance) || []).filter(function (item) {
+        if (instanceStructure.instance.constructor.prototype.hasOwnProperty(item) && Object.getOwnPropertyDescriptor(instanceStructure.instance.constructor.prototype, item).get === undefined) {
+            // Property does not have getter
+            return false;
+        }
         return objectKeys.indexOf(item) < 0;
     }));
     objectKeys.forEach(function (key) {

--- a/src/main/DeserializationHelper.ts
+++ b/src/main/DeserializationHelper.ts
@@ -1,5 +1,5 @@
 import { JsonConverstionError, JsonPropertyDecoratorMetadata, AccessType , Deserializer} from "./DecoratorMetadata";
-import { isSimpleType, getTypeName, getCachedType, getTypeNameFromInstance, getJsonPropertyDecoratorMetadata, isArrayType, Constants } from "./ReflectHelper";
+import { isSimpleType, getTypeName, getCachedType, getTypeNameFromInstance, getJsonPropertyDecoratorMetadata, isArrayType, Constants, METADATA_JSON_PROPERTIES_NAME } from "./ReflectHelper";
 
 var SimpleTypeCoverter = (value: any, type: string): any => {
     return type === Constants.DATE_TYPE ? new Date(value) : value;
@@ -71,7 +71,7 @@ export var DeserializeComplexType = (instance: Object, instanceKey: string, type
         objectInstance = instance;
     }
 
-    Object.keys(objectInstance).forEach((key: string) => {
+    Object.keys(objectInstance).concat(Reflect.getMetadata(METADATA_JSON_PROPERTIES_NAME, objectInstance)).forEach((key: string) => {
         /**
          * Check if there is any DecoratorMetadata attached to this property, otherwise create a new one.
          */

--- a/src/main/DeserializationHelper.ts
+++ b/src/main/DeserializationHelper.ts
@@ -75,12 +75,6 @@ export var DeserializeComplexType = (instance: Object, instanceKey: string, type
     objectKeys = objectKeys.concat((Reflect.getMetadata(METADATA_JSON_PROPERTIES_NAME, objectInstance) || []).filter(function(item) {
         return objectKeys.indexOf(item) < 0;
     }));
-    objectKeys = objectKeys.concat(Object.keys(json).filter(function(item) {
-        if(Reflect.getMetadata("design:type", objectInstance, item) === undefined) {
-            return false;
-        }
-        return objectKeys.indexOf(item) < 0;
-    }));
     objectKeys.forEach((key: string) => {
         /**
          * Check if there is any DecoratorMetadata attached to this property, otherwise create a new one.

--- a/src/main/DeserializationHelper.ts
+++ b/src/main/DeserializationHelper.ts
@@ -75,6 +75,12 @@ export var DeserializeComplexType = (instance: Object, instanceKey: string, type
     objectKeys = objectKeys.concat((Reflect.getMetadata(METADATA_JSON_PROPERTIES_NAME, objectInstance) || []).filter(function(item) {
         return objectKeys.indexOf(item) < 0;
     }));
+    objectKeys = objectKeys.concat(Object.keys(json).filter(function(item) {
+        if(Reflect.getMetadata("design:type", objectInstance, item) === undefined) {
+            return false;
+        }
+        return objectKeys.indexOf(item) < 0;
+    }));
     objectKeys.forEach((key: string) => {
         /**
          * Check if there is any DecoratorMetadata attached to this property, otherwise create a new one.

--- a/src/main/DeserializationHelper.ts
+++ b/src/main/DeserializationHelper.ts
@@ -72,7 +72,11 @@ export var DeserializeComplexType = (instance: Object, instanceKey: string, type
     }
 
     let objectKeys: string[] = Object.keys(objectInstance);
-    objectKeys = objectKeys.concat((Reflect.getMetadata(METADATA_JSON_PROPERTIES_NAME, objectInstance) || []).filter(function(item) {
+    objectKeys = objectKeys.concat((Reflect.getMetadata(METADATA_JSON_PROPERTIES_NAME, objectInstance) || []).filter(function(item: string) {
+        if(objectInstance.constructor.prototype.hasOwnProperty(item) && Object.getOwnPropertyDescriptor(objectInstance.constructor.prototype, item).set === undefined) {
+            // Property does not have setter
+            return false;
+        }
         return objectKeys.indexOf(item) < 0;
     }));
     objectKeys.forEach((key: string) => {

--- a/src/main/DeserializationHelper.ts
+++ b/src/main/DeserializationHelper.ts
@@ -71,7 +71,11 @@ export var DeserializeComplexType = (instance: Object, instanceKey: string, type
         objectInstance = instance;
     }
 
-    Object.keys(objectInstance).concat(Reflect.getMetadata(METADATA_JSON_PROPERTIES_NAME, objectInstance)).forEach((key: string) => {
+    let objectKeys: string[] = Object.keys(objectInstance);
+    objectKeys = objectKeys.concat((Reflect.getMetadata(METADATA_JSON_PROPERTIES_NAME, objectInstance) || []).filter(function(item) {
+        return objectKeys.indexOf(item) < 0;
+    }));
+    objectKeys.forEach((key: string) => {
         /**
          * Check if there is any DecoratorMetadata attached to this property, otherwise create a new one.
          */

--- a/src/main/ReflectHelper.ts
+++ b/src/main/ReflectHelper.ts
@@ -6,6 +6,11 @@ import 'reflect-metadata';
 import { JsonPropertyDecoratorMetadata, JSON_PROPERTY_DECORATOR_NAME } from './DecoratorMetadata';
 
 /**
+ * Reflect Metadata json properties storage name.
+ */
+export const METADATA_JSON_PROPERTIES_NAME = "JsonProperties";
+
+/**
  * Returns the JsonProperty decorator metadata.
  */
 export var getJsonPropertyDecoratorMetadata = (target: any, key: string): JsonPropertyDecoratorMetadata => {
@@ -29,7 +34,12 @@ export var getKeyName = (target: any, key: string): string => {
  * Returns the JsonPropertyDecoratorMetadata for the property
  */
 export function getJsonPropertyDecorator(metadata: any) {
-    return getPropertyDecorator(JSON_PROPERTY_DECORATOR_NAME, metadata);
+    return function(target: any, propertyKey: string) {
+        let properties: string[] = Reflect.getMetadata(METADATA_JSON_PROPERTIES_NAME, target) || [];
+        properties.push(propertyKey);
+        Reflect.defineMetadata(METADATA_JSON_PROPERTIES_NAME, properties, target);
+        getPropertyDecorator(JSON_PROPERTY_DECORATOR_NAME, metadata)(target, propertyKey);
+    };
 }
 
 export function getPropertyDecorator(metadataKey: string, metadata: any) {

--- a/src/main/SerializationHelper.ts
+++ b/src/main/SerializationHelper.ts
@@ -1,5 +1,5 @@
 import { JsonPropertyDecoratorMetadata, AccessType, Serializer, CacheKey } from "./DecoratorMetadata";
-import { isArrayType, isSimpleType, getCachedType, getTypeNameFromInstance, getJsonPropertyDecoratorMetadata, getTypeName, getKeyName, Constants } from "./ReflectHelper";
+import { isArrayType, isSimpleType, getCachedType, getTypeNameFromInstance, getJsonPropertyDecoratorMetadata, getTypeName, getKeyName, Constants, METADATA_JSON_PROPERTIES_NAME } from "./ReflectHelper";
 
 export interface SerializationStructure {
     id: string, /** id of the current structure */
@@ -72,7 +72,11 @@ export var mergeObjectOrArrayValues = (instanceStructure: SerializationStructure
 export var SerializeObjectType = (parentStructure: SerializationStructure, instanceStructure: SerializationStructure, instanceIndex: number): Array<SerializationStructure> => {
     let furtherSerializationStructures: Object = new Object();
     instanceStructure.visited = true;
-    Object.keys(instanceStructure.instance).forEach((key: string) => {
+    let objectKeys: string[] = Object.keys(instanceStructure.instance);
+    objectKeys = objectKeys.concat((Reflect.getMetadata(METADATA_JSON_PROPERTIES_NAME, instanceStructure.instance) || []).filter(function(item) {
+        return objectKeys.indexOf(item) < 0;
+    }));
+    objectKeys.forEach((key: string) => {
         let keyInstance = instanceStructure.instance[key];
         if (keyInstance != undefined) {
             let metadata: JsonPropertyDecoratorMetadata = getJsonPropertyDecoratorMetadata(instanceStructure.instance, key);

--- a/src/main/SerializationHelper.ts
+++ b/src/main/SerializationHelper.ts
@@ -73,7 +73,11 @@ export var SerializeObjectType = (parentStructure: SerializationStructure, insta
     let furtherSerializationStructures: Object = new Object();
     instanceStructure.visited = true;
     let objectKeys: string[] = Object.keys(instanceStructure.instance);
-    objectKeys = objectKeys.concat((Reflect.getMetadata(METADATA_JSON_PROPERTIES_NAME, instanceStructure.instance) || []).filter(function(item) {
+    objectKeys = objectKeys.concat((Reflect.getMetadata(METADATA_JSON_PROPERTIES_NAME, instanceStructure.instance) || []).filter(function(item: string) {
+        if(instanceStructure.instance.constructor.prototype.hasOwnProperty(item) && Object.getOwnPropertyDescriptor(instanceStructure.instance.constructor.prototype, item).get === undefined) {
+            // Property does not have getter
+            return false;
+        }
         return objectKeys.indexOf(item) < 0;
     }));
     objectKeys.forEach((key: string) => {


### PR DESCRIPTION
No need to specify class properties as undefined.

Before:

```typescript
class SimpleRoster {
    private name: String = undefined;
    ...
}
```

After:

```typescript
class SimpleRoster {
    @JsonProperty()
    private name: String;
    ...
}
```