### PR TITLE
Bugfix: nested array is undefined

### DIFF
--- a/dist/ObjectMapper.es2015.js
+++ b/dist/ObjectMapper.es2015.js
@@ -191,12 +191,12 @@ var DeserializeDateType = function (instance, instanceKey, type, json, jsonKey) 
  * Deserializes a JS array type from json.
  */
 var DeserializeArrayType = function (instance, instanceKey, type, json, jsonKey) {
-    var jsonObject = jsonKey != undefined ? json[jsonKey] : json;
+    var jsonObject = (jsonKey != undefined) ? (json[jsonKey] || []) : json;
     var jsonArraySize = jsonObject.length;
     var conversionFunctionsList = new Array();
+    var arrayInstance = [];
+    instance[instanceKey] = arrayInstance;
     if (jsonArraySize > 0) {
-        var arrayInstance = [];
-        instance[instanceKey] = arrayInstance;
         for (var i = 0; i < jsonArraySize; i++) {
             var typeName = getTypeNameFromInstance(type);
             if (!isSimpleType(typeName)) {

--- a/src/main/DeserializationHelper.ts
+++ b/src/main/DeserializationHelper.ts
@@ -33,12 +33,12 @@ export var DeserializeDateType = (instance: Object, instanceKey: string, type: a
  * Deserializes a JS array type from json.
  */
 export var DeserializeArrayType = (instance: Object, instanceKey: string, type: any, json: Object, jsonKey: string): Array<ConversionFunctionStructure> => {
-    let jsonObject = jsonKey != undefined ? json[jsonKey] : json;
+    let jsonObject = (jsonKey != undefined) ? (json[jsonKey] || []) : json;
     let jsonArraySize = jsonObject.length;
     let conversionFunctionsList = new Array<ConversionFunctionStructure>();
+    let arrayInstance = [];
+    instance[instanceKey] = arrayInstance;
     if (jsonArraySize > 0) {
-        let arrayInstance = [];
-        instance[instanceKey] = arrayInstance;
         for (var i = 0; i < jsonArraySize; i++) {
             let typeName = getTypeNameFromInstance(type);
             if (!isSimpleType(typeName)) {

--- a/src/test/DeserializationHelper.spec.ts
+++ b/src/test/DeserializationHelper.spec.ts
@@ -113,6 +113,38 @@ describe("Testing Conversion functions", () => {
         expect(testInstance.field.length).toBe(3);
     });
 
+    it("Test DeserializeArrayType - undefined array ", () => {
+        class ComplexType {
+            f: number = Math.random();
+        }
+        class testObject10 {
+            field1: ComplexType[];
+            field2: string[];
+        }
+
+        var json = { 'objects': [] }
+        var testInstance1 = new testObject10();
+        var testInstance2 = new testObject10();
+
+        var moreFunctionsList1 = DeserializeArrayType(testInstance1, "field1", ComplexType, json, "objects");
+        var moreFunctionsList2 = DeserializeArrayType(testInstance1, "field2", String, json, "objects");
+        var moreFunctionsList3 = DeserializeArrayType(testInstance2, "field1", ComplexType, {}, "objects");
+        var moreFunctionsList4 = DeserializeArrayType(testInstance2, "field2", String, {}, "objects");
+
+        expect(moreFunctionsList1.length).toBe(0);
+        expect(moreFunctionsList2.length).toBe(0);
+        expect(moreFunctionsList3.length).toBe(0);
+        expect(moreFunctionsList4.length).toBe(0);
+        expect(Array.isArray(testInstance1.field1)).toBe(true);
+        expect(Array.isArray(testInstance1.field2)).toBe(true);
+        expect(Array.isArray(testInstance2.field1)).toBe(true);
+        expect(Array.isArray(testInstance2.field2)).toBe(true);
+        expect(testInstance1.field1.length).toBe(0);
+        expect(testInstance1.field2.length).toBe(0);
+        expect(testInstance2.field1.length).toBe(0);
+        expect(testInstance2.field2.length).toBe(0);
+    });
+
     it("Test DeserializeComplexType - simple class ", () => {
         class DeserializeComplexTypeSimpleClassTest {
             @JsonProperty()


### PR DESCRIPTION
Before:

```typescript
class TestObject {
    @JsonProperty()
    public field: string[];
}

let json = {};
let result = ObjectMapper.deserialize(TestObject, json);
Array.isArray(result.field); // return false, 'result.field' is undefined
```

After:

```typescript
class TestObject {
    @JsonProperty()
    public field: string[];
}

let json = {};
let result = ObjectMapper.deserialize(TestObject, json);
Array.isArray(result.field); // return true, 'result.field' is empty Array
```